### PR TITLE
Fix progress bar

### DIFF
--- a/core/lib/utils.py
+++ b/core/lib/utils.py
@@ -83,7 +83,7 @@ def getrealdir(path):
 
 def print_progressbar(tot, scanned, start_time, label):
 	perc = (scanned * 33) / (tot if tot > 0 else 1)
-	sys.stdout.write("\b"*150)
+	sys.stdout.write("\r")
 	out = "[%s%s]   %d of %d %s in %d minutes" % ("="*perc, " "*(33-perc), scanned, tot, label, int(time.time() - start_time) / 60)
 	stdoutw(out)
 


### PR DESCRIPTION
Change to printing a single carriage return instead of 150 backspaces, which was causing text to flow back up the terminal in some cases.